### PR TITLE
Action workflow fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ jobs:
     name: Test
     strategy:
       matrix:
-        #go_version: [1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
-        go_version: [1.19]
+        go_version: [1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
+        #go_version: [1.19]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,4 +23,4 @@ jobs:
         run: go get -v -t -d ./...
 
       - name: Test
-        run: go test -v -race ./...
+        run: go test -race ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [push, workflow_run, pull_request]
+on: [push, pull_request]
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 name: Go
-on: [push]
+on: [push, workflow_run, pull_request]
 jobs:
   test:
     name: Test
     strategy:
       matrix:
-        go_version: [1.12, 1.13, 1.14, 1.15, 1.16]
+        go_version: [1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,8 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go_version: [1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
+        #go_version: [1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
+        go_version: [1.19]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,13 @@
 name: Go
 on: [push]
+env:
+  MallocNanoZone: 0
 jobs:
   test:
     name: Test
     strategy:
       matrix:
         go_version: [1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
-        #go_version: [1.19]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,4 +24,4 @@ jobs:
         run: go get -v -t -d ./...
 
       - name: Test
-        run: go test -race ./...
+        run: go test -v -race ./...


### PR DESCRIPTION
This PR fixes the github action due to a SIGABRT received on OSX jobs, caused by: https://github.com/golang/go/issues/49138

This PR introduces the `MallocNanoZone=0` env var as suggested in the issue. Also adds new versions to the test matrix.