### PR TITLE
Make tests robust to order changes in _dd.ci.env_vars

### DIFF
--- a/internal/utils/ci_providers_test.go
+++ b/internal/utils/ci_providers_test.go
@@ -37,6 +37,13 @@ func setEnvs(env map[string]string) func() {
 	}
 }
 
+func sortJsonKeys(jsonStr string) string {
+	tmp := map[string]string{}
+	json.Unmarshal([]byte(jsonStr), &tmp)
+	jsonBytes, _ := json.Marshal(tmp)
+	return string(jsonBytes)
+}
+
 // TestTags asserts that all tags are extracted from environment variables.
 func TestTags(t *testing.T) {
 	// Reset provider env key when running in CI
@@ -95,6 +102,9 @@ func TestTags(t *testing.T) {
 
 					for expectedKey, expectedValue := range tags {
 						if actualValue, ok := providerTags[expectedKey]; ok {
+							if expectedKey == "_dd.ci.env_vars" {
+								expectedValue = sortJsonKeys(expectedValue)
+							}
 							if expectedValue != actualValue {
 								if expectedValue == strings.ReplaceAll(actualValue, "\\", "/") {
 									continue

--- a/internal/utils/testdata/fixtures/github.json
+++ b/internal/utils/testdata/fixtures/github.json
@@ -13,7 +13,7 @@
       "GITHUB_WORKSPACE": "/foo/bar"
     },
     {
-      "_dd.ci.env_vars": "{\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\"}",
+      "_dd.ci.env_vars": "{\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://ghenterprise.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",


### PR DESCRIPTION
This makes the tests still pass if the CI provider fixtures contain a `_dd.ci.env_vars` entry (which contains serialized json) with the keys not sorted alphabetically.