### PR TITLE
Use runtime.GOOS as OSPlatform for all OSes

### DIFF
--- a/internal/constants/os.go
+++ b/internal/constants/os.go
@@ -8,12 +8,12 @@ package constants
 const (
 	Unknown = "unknown"
 
-	// OSPlatform indicates name of the operating system.
+	// OSPlatform indicates the operating system family (eg: linux).
 	OSPlatform = "os.platform"
 
 	// OSVersion indicates version of the operating system.
 	OSVersion = "os.version"
 
-	// OSArchitecture indicates git repository URL related to the build.
+	// OSArchitecture indicates the architecture this sdk is built for (could be 32 bit on a 64 bit system)
 	OSArchitecture = "os.architecture"
 )

--- a/internal/utils/osinfo_darwin.go
+++ b/internal/utils/osinfo_darwin.go
@@ -7,15 +7,10 @@ package utils
 
 import (
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/DataDog/dd-sdk-go-testing/internal/constants"
 )
-
-func OSName() string {
-	return runtime.GOOS
-}
 
 func OSVersion() string {
 	out, err := exec.Command("sw_vers", "-productVersion").Output()

--- a/internal/utils/osinfo_default.go
+++ b/internal/utils/osinfo_default.go
@@ -8,14 +8,8 @@
 package utils
 
 import (
-	"runtime"
-
 	"github.com/DataDog/dd-sdk-go-testing/internal/constants"
 )
-
-func OSName() string {
-	return runtime.GOOS
-}
 
 func OSVersion() string {
 	return constants.Unknown

--- a/internal/utils/osinfo_freebsd.go
+++ b/internal/utils/osinfo_freebsd.go
@@ -7,15 +7,10 @@ package utils
 
 import (
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/DataDog/dd-sdk-go-testing/internal/constants"
 )
-
-func OSName() string {
-	return runtime.GOOS
-}
 
 func OSVersion() string {
 	out, err := exec.Command("uname", "-r").Output()

--- a/internal/utils/osinfo_linux.go
+++ b/internal/utils/osinfo_linux.go
@@ -13,24 +13,6 @@ import (
 	"github.com/DataDog/dd-sdk-go-testing/internal/constants"
 )
 
-func OSName() string {
-	f, err := os.Open("/etc/os-release")
-	if err != nil {
-		return "Linux (Unknown Distribution)"
-	}
-	defer f.Close()
-	s := bufio.NewScanner(f)
-	name := "Linux (Unknown Distribution)"
-	for s.Scan() {
-		parts := strings.SplitN(s.Text(), "=", 2)
-		switch parts[0] {
-		case "Name":
-			name = strings.Trim(parts[1], "\"")
-		}
-	}
-	return name
-}
-
 func OSVersion() string {
 	f, err := os.Open("/etc/os-release")
 	if err != nil {

--- a/internal/utils/osinfo_windows.go
+++ b/internal/utils/osinfo_windows.go
@@ -7,16 +7,11 @@ package utils
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/DataDog/dd-sdk-go-testing/internal/constants"
 	"golang.org/x/sys/windows/registry"
 )
-
-func OSName() string {
-	return runtime.GOOS
-}
 
 func OSVersion() string {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)

--- a/option.go
+++ b/option.go
@@ -55,7 +55,7 @@ func ensureCITags() {
 
 func ensureCITagsLocked() {
 	localTags := utils.GetProviderTags()
-	localTags[constants.OSPlatform] = utils.OSName()
+	localTags[constants.OSPlatform] = runtime.GOOS
 	localTags[constants.OSVersion] = utils.OSVersion()
 	localTags[constants.OSArchitecture] = runtime.GOARCH
 	localTags[constants.RuntimeName] = runtime.Compiler


### PR DESCRIPTION
It was only different on Linux, where we tried to get the distro name. However, the logic was broken (we checked for a `Name` variable in `os-releases` but it's actually called `NAME`) so we would only report `Linux (Unknown distro)`.