### PR TITLE
fix: filter sensitive information from git-retrieved repository URL

### DIFF
--- a/internal/utils/git.go
+++ b/internal/utils/git.go
@@ -42,7 +42,7 @@ func LocalGetGitData() (LocalGitData, error) {
 	if err != nil {
 		return gitData, err
 	}
-	gitData.RepositoryUrl = strings.Trim(string(out), "\n")
+	gitData.RepositoryUrl = filterSensitiveInfo(strings.Trim(string(out), "\n"))
 
 	// Extract the branch name
 	out, err = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()


### PR DESCRIPTION
During `GetProviderTags()` the git repsotiry URL is filtered for sensitive
information.

When falling back to `LocalGetGitData()`, `filterSensitiveInfo()` is not
applied, causing a potential leak of credentials if they are encoded in the
remote URL of the underyling git repository.
